### PR TITLE
Add manytracks example

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -327,3 +327,9 @@
   license: AGPL-3.0
   location: https://github.com/TAMU-CPT/SitewideNotices/
   gmodProject: JBrowse
+- author: Colin Diesh
+  description: |
+    JBrowse plugin to make a list of tracks from a base track config and list of file URLs
+  gmodProject: JBrowse
+  location: https://github.com/cmdcolin/manytracks
+  name: manytracks


### PR DESCRIPTION
New plugin to help in configuring long lists of tracks, link here https://github.com/cmdcolin/manytracks


The idea is that before, you had something like this, which can be cumbersome to maintain
```
[tracks.blah1]
urlTemplate=blah1.bam
type=...
storeClass=...
[tracks.blah2]
urlTemplate=blah2.bam
type=...
storeClass=...
[tracks.blah3]
urlTemplate=blah3.bam
type=...
storeClass=...
```


Where this plugin allows you to just say

```
[manytracks.blah]
type=...
storeClass=...
urlTemplates+=blah1.bam
urlTemplates+=blah2.bam
urlTemplates+=blah3.bam
```

This could potentially be made part of JBrowse core, but I thought it could be interesting as a plugin also